### PR TITLE
TASK-12894: added new tile type

### DIFF
--- a/types/tiles.go
+++ b/types/tiles.go
@@ -3,22 +3,23 @@ package types
 // ListTile is a 9 Spokes V2 "List" tile data format
 type ListTile struct {
 	SubHeader struct {
-		ValueLeft float64 `json:"valueLeft,omitempty"`
+		ValueLeft string `json:"valueLeft,omitempty"`
 	} `json:"subheader,omitempty"`
-	List []ListTileEntry `json:"list,omitempty"`
+	List     []ListTileEntry `json:"list,omitempty"`
+	SyncedAt string          `json:"lastSyncAt,omitempty"`
 }
 
 // ListTileEntry is an entry in a ListTile
 type ListTileEntry struct {
-	Label     string  `json:"label,omitempty"`
-	Value     float64 `json:"value,omitempty"`
-	Indicator string  `json:"indicator,omitempty"`
-	Left      string  `json:"left,omitempty"`
-	Right     string  `json:"right,omitempty"`
-	IsSubRow  bool    `json:"isSubRow,omitempty"`
+	Label     string `json:"label,omitempty"`
+	Value     string `json:"value,omitempty"`
+	Indicator string `json:"indicator,omitempty"`
+	Left      string `json:"left,omitempty"`
+	Right     string `json:"right,omitempty"`
+	IsSubRow  bool   `json:"isSubRow,omitempty"`
 	Footer    struct {
-		Label string  `json:"label,omitempty"`
-		Value float64 `json:"value,omitempty"`
+		Label string `json:"label,omitempty"`
+		Value string `json:"value,omitempty"`
 	} `json:"footer,omitempty"`
 }
 
@@ -31,4 +32,15 @@ type GraphTile struct {
 		Key  string    `json:"key,omitempty"`
 		Data []float64 `json:"data,omitempty"`
 	} `json:"series,omitempty"`
+	SyncedAt string `json:"lastSyncAt,omitempty"`
+}
+
+// CompositeListTile is a 9 Spokes V2 special "List" tile data format
+// It's made up of multiple ListTile blocks so the tile can switch
+// between them
+type CompositeListTile struct {
+	GroupedData []struct {
+		Key  string `json:"key,omitempty"`
+		Data ListTile
+	} `json:"groupedData,omitempty"`
 }


### PR DESCRIPTION
Added a new tile type for list tiles that display multiple tile data, such as OCBC's and OpenBanking's Last 10 Transactions.

Also changed the `Value` type from `float64` to `string` as not all values are numeric.