### PR TITLE
BUG-29139: don't omit balances when they are 0

### DIFF
--- a/services/realtime/types.go
+++ b/services/realtime/types.go
@@ -3,8 +3,8 @@ package realtime
 type BankingAccount struct {
 	ID               string  `json:"account_id,omitempty"`
 	Active           bool    `json:"account_active,omitempty"`
-	CurrentBalance   float64 `json:"account_current_balance,omitempty"`
-	AvailableBalance float64 `json:"account_available_balance,omitempty"`
+	CurrentBalance   float64 `json:"account_current_balance"`
+	AvailableBalance float64 `json:"account_available_balance"`
 	Currency         string  `json:"account_currency,omitempty"`
 	Name             string  `json:"account_name,omitempty"`
 	Type             string  `json:"account_type,omitempty"`


### PR DESCRIPTION
The account available or current balance can sometimes be 0 and when that happens we don't want to omit it.

For example, below is an account details response:
```
{
    "depositAccount": {
        "accountId": "ccbc687d380885b882a00020a7d12f2ad7c174f495bf379a22075fa75bac50fc",
        "accountType": "CHECKING",
        "accountNumber": "000000024819",
        "accountNumberDisplay": "xxxxxxxx4819",
        "productName": "Adv Tiered Interest Chkg",
        "status": "OPEN",
        "description": "Adv Tiered Interest Chkg",
        "currency": {
            "currencyCode": "USD"
        },
        "fiAttributes": [
            {
                "name": "displayName",
                "value": "Adv Tiered Interest Chkg - 4819"
            },
            {
                "name": "accountOpenedDate",
                "value": "1988-02-29"
            },
            {
                "name": "interestPaidLastYear",
                "value": "169.45"
            }
        ],
        "lineOfBusiness": "Personal",
        "routingTransitNumber": "111000025",
        "balanceType": "ASSET",
        "transactionsIncluded": false,
        "balanceAsOf": "2023-01-25T06:50:06.190+0000",
        "currentBalance": 17160.08,
        "availableBalance": 0.00,
        "interestYtd": 286.38
    }
}
```
which would have been mapped to 
```
{
            "account_id": "ccbc687d380885b882a00020a7d12f2ad7c174f495bf379a22075fa75bac50fc",
            "account_active": true,
            "account_current_balance": 17160.08,
            "account_currency": "USD",
            "account_name": "Adv Tiered Interest Chkg",
            "account_type": "CHECKING",
            "account_category": "Personal",
            "account_status": "OPEN",
            "account_number": "000000024819",
            "account_number_display": "xxxxxxxx4819"
}
```