### PR TITLE
Task 31304

### DIFF
--- a/logging/v2/syslog_mac.go
+++ b/logging/v2/syslog_mac.go
@@ -1,0 +1,8 @@
+//go:build darwin
+
+package logging
+
+func NewSyslog(host, tag string) *LoggerLocal {
+	return NewOplogging(host, tag)
+
+}

--- a/logging/v3/syslog_mac.go
+++ b/logging/v3/syslog_mac.go
@@ -1,0 +1,8 @@
+//go:build darwin
+
+package logging
+
+func NewSyslog(host, tag string) *LoggerLocal {
+	return NewOplogging(host, tag)
+
+}


### PR DESCRIPTION
TASK-31304: add a function to parse a client certificate forwarded from ingress controller in a custom HTTP header

Add a function to check if given certificate is part of trusted certs (array)
The check is simple contains() i.e. by exact match, rather than building a chain of trust